### PR TITLE
fix: CORS preflights failing

### DIFF
--- a/src/utils/cors.rs
+++ b/src/utils/cors.rs
@@ -1,6 +1,6 @@
 use rocket::{Request, Response};
 use rocket::fairing::{Fairing, Info, Kind};
-use rocket::http::Header;
+use rocket::http::{Header, Method, Status};
 
 pub struct CORS();
 
@@ -13,7 +13,13 @@ impl Fairing for CORS {
         }
     }
 
-    async fn on_response<'r>(&self, _: &'r Request<'_>, response: &mut Response<'r>) {
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
+        if request.method() == Method::Options {
+            // fix OPTIONS preflights returning 404
+            // and preventing calls from working
+            response.set_status(Status::NoContent);
+        }
+
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
         response.set_header(Header::new("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE"));
         response.set_header(Header::new("Access-Control-Allow-Headers", "*"));


### PR DESCRIPTION
At the moment, requests to the API from a secure context fail in web browsers
(and electron apps like Discord!)

This is because they preflight CORS requests by sending an `OPTIONS` request.

This makes the server respond `204 No Content` so that those requests succeed,
instead of `404 Not Found` due to no routes accepting the `OPTIONS` method.

I have tested this locally, and it works fine.